### PR TITLE
Get rid of a few deprecation warnings

### DIFF
--- a/src/stellar_table.jl
+++ b/src/stellar_table.jl
@@ -62,8 +62,8 @@ function setup(filename::String; force_reread::Bool = false)
   usable = find(is_usable)
   df = df[usable, symbols_to_keep]
   end
-    df[:wf_id] = map(x->ExoplanetsSysSim.WindowFunction.get_window_function_id(x,use_default_for_unknown=false),df[:kepid])
-    obs_5q = df[:wf_id].!=-1
+    df[!,:wf_id] = map(x->ExoplanetsSysSim.WindowFunction.get_window_function_id(x,use_default_for_unknown=false),df[!,:kepid])
+    obs_5q = df[!,:wf_id].!=-1
     #df = df[obs_5q,keys(df.colindex)]
     df = df[obs_5q,names(df)]
     StellarTable.set_star_table(df)


### PR DESCRIPTION
Also, in src/simulation_parameters.jl, I am getting a "Pkg.installed() is deprecated" message every time I call SimParam() in Julia 1.4.
Can this be addressed somehow (e.g. line 48 in that file)? I haven't made any changes.

Thanks,
Matthias